### PR TITLE
Add command to fetch receipts

### DIFF
--- a/jarbas/core/management/commands/receipts.py
+++ b/jarbas/core/management/commands/receipts.py
@@ -1,0 +1,23 @@
+from django.core.management.base import BaseCommand
+
+from jarbas.core.models import Reimbursement
+
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **options):
+        print('Loading…')
+        queryset = Reimbursement.objects.filter(receipt_fetched=False)
+        self.count = 0
+
+        for reimbursement in queryset:
+            reimbursement.get_receipt_url()
+            self.count += 1
+            self.print_count()
+
+        self.print_count(permanent=True)
+        print('Done!')
+
+    def print_count(self, **kwargs):
+        end = '\n' if kwargs.get('permanent') else '\r'
+        print('{:,} receipt URLs fetched…'.format(self.count), end=end)

--- a/jarbas/core/models.py
+++ b/jarbas/core/models.py
@@ -71,7 +71,7 @@ class Reimbursement(models.Model):
     probability = models.DecimalField('Probability', max_digits=6, decimal_places=5, blank=True, null=True)
     suspicions = JSONField('Suspicions', blank=True, null=True)
 
-    receipt_fetched = models.BooleanField('Was the receipt URL fetched?', default=False)
+    receipt_fetched = models.BooleanField('Was the receipt URL fetched?', default=False, db_index=True)
     receipt_url = models.CharField('Receipt URL', max_length=140, blank=True, null=True)
 
     class Meta:
@@ -112,6 +112,14 @@ class Reimbursement(models.Model):
 
         parts = list(content.split(','))
         return list(map(lambda x: cast(x), parts)) if cast else parts
+
+    def __repr__(self):
+        unique_id = (
+            'year={year}, '
+            'applicant_id={applicant_id}, '
+            'document_id={document_id}'
+        ).format(**self.__dict__)
+        return 'Reimbursement({})'.format(unique_id)
 
 
 class Document(models.Model):

--- a/jarbas/core/tests/test_receipts_command.py
+++ b/jarbas/core/tests/test_receipts_command.py
@@ -1,0 +1,26 @@
+from unittest.mock import call, patch
+
+from django.test import TestCase
+
+from jarbas.core.management.commands.receipts import Command
+from jarbas.core.models import Reimbursement
+from jarbas.core.tests import sample_reimbursement_data
+
+
+class TestCommand(TestCase):
+
+
+    @patch.object(Reimbursement, 'get_receipt_url')
+    @patch('jarbas.core.management.commands.receipts.print')
+    def test_update(self, print_, get_receipt_url):
+        Reimbursement.objects.create(**sample_reimbursement_data)
+        command = Command()
+        command.handle()
+        self.assertEqual(1, get_receipt_url.call_count)
+        self.assertEqual(1, command.count)
+        print_.asset_has_calls([
+            call('Loading…'),
+            call('1 receipt URLs fetched…', end='\r'),
+            call('1 receipt URLs fetched…', end='\n'),
+            call('Done!'),
+        ])

--- a/jarbas/core/tests/test_reimbursement_model.py
+++ b/jarbas/core/tests/test_reimbursement_model.py
@@ -77,6 +77,16 @@ class TestCustomMethods(TestReimbursement):
             list(reimbursement.all_net_values)
         )
 
+    def test_repr(self):
+        obj = Reimbursement.objects.create(**self.data)
+        expected = (
+            'Reimbursement('
+            'year=1970, '
+            'applicant_id=13, '
+            'document_id=42)'
+        )
+        self.assertEqual(expected, obj.__repr__())
+
 
 class TestReceipt(TestCase):
 


### PR DESCRIPTION
Takes ages, must be rewrite using lauching multiple `Reimbursement.get_receipt_url()` in parallel…

… but that's what we've got now.