### PR TITLE
Fixing translation for input labels

### DIFF
--- a/jarbas/frontend/elm/Documents/Update.elm
+++ b/jarbas/frontend/elm/Documents/Update.elm
@@ -56,7 +56,7 @@ newSearch model =
         | results = results
         , showForm = True
         , loading = False
-        , inputs = Documents.Inputs.Model.model
+        , inputs = Inputs.updateLanguage model.lang Documents.Inputs.Model.model
     }
 
 


### PR DESCRIPTION
The input labels wasn't translating to the browser language. Even in the [official website](http://jarbas.datasciencebr.com/), the sidebar was translating to _Portuguese_ and input labels was in _English_.