### PR TITLE
Set nginx to always use HTTPS

### DIFF
--- a/Dockerfile-nginx
+++ b/Dockerfile-nginx
@@ -1,3 +1,3 @@
 FROM nginx:1.11.5
-COPY contrib/nginx /etc/nginx/conf.d/default.conf
+COPY contrib/nginx.docker /etc/nginx/conf.d/default.conf
 RUN mkdir -p /opt/jarbas

--- a/contrib/nginx
+++ b/contrib/nginx
@@ -1,21 +1,32 @@
-resolver 127.0.0.11 valid=1s;
-
-
 server {
-    access_log /dev/stdout;
-    server_name localhost;
-    set $alias "apps";
-    access_log on;
+    listen              443 ssl;
+    server_name         jarbas.datasciencebr.com;
+    ssl_certificate     /etc/letsencrypt/live/jarbas.datasciencebr.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/jarbas.datasciencebr.com/privkey.pem;
+    ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
+    access_log          on;
+
+    location /.well-known/ {
+        alias /opt/jarbas/staticfiles/.well-known/;
+    }
 
     location /static/ {
         alias /opt/jarbas/staticfiles/;
     }
 
     location / {
-        proxy_pass http://$alias:8001;
-        proxy_set_header Host $host;
-        proxy_set_header X-Forwarded-Host $server_name;
-        proxy_set_header X-Real-IP $remote_addr;
-        add_header P3P 'CP="ALL DSP COR PSAa PSDa OUR NOR ONL UNI COM NAV"';
+        proxy_pass          http://127.0.0.1:8001;
+        proxy_set_header    Host $host;
+        proxy_set_header    X-Forwarded-Host $server_name;
+        proxy_set_header    X-Real-IP $remote_addr;
+        add_header          P3P 'CP="ALL DSP COR PSAa PSDa OUR NOR ONL UNI COM NAV"';
     }
 }
+
+server {
+    listen      80;
+    server_name jarbas.datasciencebr.com;
+    return      301 https://jarbas.datasciencebr.com$request_uri;
+}
+

--- a/contrib/nginx.docker
+++ b/contrib/nginx.docker
@@ -1,0 +1,21 @@
+resolver 127.0.0.11 valid=1s;
+
+
+server {
+    access_log /dev/stdout;
+    server_name localhost;
+    set $alias "apps";
+    access_log on;
+
+    location /static/ {
+        alias /opt/jarbas/staticfiles/;
+    }
+
+    location / {
+        proxy_pass http://$alias:8001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Host $server_name;
+        proxy_set_header X-Real-IP $remote_addr;
+        add_header P3P 'CP="ALL DSP COR PSAa PSDa OUR NOR ONL UNI COM NAV"';
+    }
+}


### PR DESCRIPTION
**Note**: The `contrib/nginx` was prepared for the future Docker provision/deploy and was outdated with the current settings. I moved it to `contrib/nginx.docker` and kept the current version as `contrib/nginx` (cc @gomex @gwmoura).