### PR TITLE
Use bulk update in receipts command

### DIFF
--- a/jarbas/core/management/commands/receipts.py
+++ b/jarbas/core/management/commands/receipts.py
@@ -1,6 +1,7 @@
 from concurrent import futures
 from time import sleep
 
+from bulk_update.helper import bulk_update
 from django.core.management.base import BaseCommand
 
 from jarbas.core.models import Reimbursement
@@ -22,45 +23,61 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         self.batch, self.pause = options['batch_size'], options['pause']
         self.count = 0
+        self.queue = []
 
-        print('Loading…', end='\r')
+        print('Loading…')
         self.queryset = self.get_queryset()
 
         if self.queryset:
-            self.fetch()
+            while self.queryset:
+                self.fetch()
+                self.queryset = self.get_queryset()
+                if self.queryset:
+                    self.print_pause()
+                    sleep(self.pause)
+            else:
+                self.print_count(permanent=True)
+                print('Done!')
         else:
             print('Nothing to fetch.')
 
     def fetch(self):
-        while self.queryset:
-            with futures.ThreadPoolExecutor(max_workers=32) as executor:
-                for result in executor.map(self.update, self.queryset):
-                    self.count += 1
-                    self.print_count()
+        with futures.ThreadPoolExecutor(max_workers=32) as executor:
+            for result in executor.map(self.update, self.queryset):
+                self.count += 1
+                self.print_count()
+        self.bulk_update()
 
-            self.queryset = self.get_queryset()
-            if self.queryset:
-                self.print_count(pause=True)
-                sleep(self.pause)
-        else:
-            self.print_count(permanent=True)
-            print('Done!')
+    def bulk_update(self):
+        self.print_saving()
+        fields = ['receipt_url', 'receipt_fetched']
+        bulk_update(self.queue, update_fields=fields)
+        self.queue = []
 
     def get_queryset(self):
         return Reimbursement.objects.filter(receipt_fetched=False)[:self.batch]
 
+    def update(self, reimbursement):
+        self.queue.append(reimbursement.get_receipt_url(bulk=True))
+
     @staticmethod
-    def update(reimbursement):
-        reimbursement.get_receipt_url()
+    def print_msg(msg, permanent=False):
+        if not permanent:
+            cursor_up_one = '\x1b[1A'
+            erase_line = '\x1b[2K'
+            print('{}{}{}'.format(cursor_up_one, erase_line, cursor_up_one))
+        print(msg)
+
+    def count_msg(self):
+        return '{:,} receipt URLs fetched'.format(self.count)
 
     def print_count(self, **kwargs):
-        pause_msg = 'Taking a break to avoid being blocked…'
-        count_msg = '{:,} receipt URLs fetched'.format(self.count)
+        return self.print_msg(self.count_msg(), **kwargs)
 
-        if kwargs.get('pause'):
-            msg = '{} ({})'.format(count_msg, pause_msg)
-        else:
-            msg = count_msg + (' ' * (len(pause_msg) + 3))
+    def print_pause(self, **kwargs):
+        pause_msg = '{} (Taking a break to avoid being blocked…)'
+        return self.print_msg(pause_msg.format(self.count_msg()), **kwargs)
 
-        end = '\n' if kwargs.get('permanent') else '\r'
-        print(msg, end=end)
+    def print_saving(self, **kwargs):
+        saving_msg = '{} (Saving the URLs to the database…)'
+        return self.print_msg(saving_msg.format(self.count_msg()), **kwargs)

--- a/jarbas/core/models.py
+++ b/jarbas/core/models.py
@@ -80,7 +80,7 @@ class Reimbursement(models.Model):
         ordering = ['-issue_date']
         unique_together = ('year', 'applicant_id', 'document_id')
 
-    def get_receipt_url(self, force=False):
+    def get_receipt_url(self, force=False, bulk=False):
         if self.receipt_url:
             return self.receipt_url
 
@@ -91,8 +91,11 @@ class Reimbursement(models.Model):
         if receipt.exists:
             self.receipt_url = receipt.url
         self.receipt_fetched = True
-        self.save()
 
+        if bulk:
+            return self
+
+        self.save()
         return self.receipt_url
 
     @property

--- a/jarbas/core/tests/test_reimbursement_model.py
+++ b/jarbas/core/tests/test_reimbursement_model.py
@@ -178,3 +178,11 @@ class TestReceipt(TestCase):
         self.assertEqual(self.expected_receipt_url, self.obj.receipt_url)
         self.assertTrue(self.obj.receipt_fetched)
         mocked_head.assert_called_once_with(self.expected_receipt_url)
+
+    @patch('jarbas.core.models.head')
+    def test_bulk_get_receipt_url(self, mocked_head):
+        mocked_head.return_value.status_code = 200
+        updated = self.obj.get_receipt_url(bulk=True)
+        self.assertIsInstance(updated, Reimbursement)
+        self.assertIsInstance(updated.receipt_url, str)
+        self.assertTrue(updated.receipt_fetched)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Django==1.10.4
 dj-database-url==0.4.1
 django-assets==0.12
+django-bulk-update==1.1.10
 django-cors-middleware==1.3.1
 django-test-without-migrations==0.4
 djangorestframework==3.5.3


### PR DESCRIPTION
Multithreading `receipts` command was opening too many db connections. This PR uses bulk update method to speed up the execution and keep the connections to the db sane ; )