### PR TITLE
Avoid stopping bulk update on HTTP error (receipts command)

### DIFF
--- a/jarbas/core/management/commands/receipts.py
+++ b/jarbas/core/management/commands/receipts.py
@@ -3,6 +3,7 @@ from time import sleep
 
 from bulk_update.helper import bulk_update
 from django.core.management.base import BaseCommand
+from requests.exceptions import ConnectionError
 
 from jarbas.core.models import Reimbursement
 
@@ -58,7 +59,12 @@ class Command(BaseCommand):
         return Reimbursement.objects.filter(receipt_fetched=False)[:self.batch]
 
     def update(self, reimbursement):
-        self.queue.append(reimbursement.get_receipt_url(bulk=True))
+        try:
+            obj = reimbursement.get_receipt_url(bulk=True)
+        except ConnectionError:
+            pass
+        else:
+            self.queue.append(obj)
 
     @staticmethod
     def print_msg(msg, permanent=False):

--- a/jarbas/core/tests/test_receipt_class.py
+++ b/jarbas/core/tests/test_receipt_class.py
@@ -2,6 +2,7 @@ from json import loads
 from unittest.mock import patch
 
 from django.test import TestCase
+from requests.exceptions import ConnectionError
 
 from jarbas.core.models import Receipt
 
@@ -24,3 +25,8 @@ class TestReceipt(TestCase):
     def test_no_existing_url(self, mocked_head):
         mocked_head.return_value.status_code = 404
         self.assertFalse(self.receipt.exists)
+
+    @patch('jarbas.core.models.head')
+    def test_connection_error(self, mocked_head):
+        mocked_head.side_effect = ConnectionError
+        self.assertIsInstance(self.receipt.exists, ConnectionError)

--- a/jarbas/core/tests/test_receipt_class.py
+++ b/jarbas/core/tests/test_receipt_class.py
@@ -29,4 +29,5 @@ class TestReceipt(TestCase):
     @patch('jarbas.core.models.head')
     def test_connection_error(self, mocked_head):
         mocked_head.side_effect = ConnectionError
-        self.assertIsInstance(self.receipt.exists, ConnectionError)
+        with self.assertRaises(ConnectionError):
+            self.receipt.exists

--- a/jarbas/core/tests/test_receipts_command.py
+++ b/jarbas/core/tests/test_receipts_command.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock, call, patch
 
 from django.test import TestCase
 from django.db.models import QuerySet
+from requests.exceptions import ConnectionError
 
 from jarbas.core.management.commands.receipts import Command
 
@@ -83,6 +84,15 @@ class TestCommandMethods(TestCase):
         command.update(reimbursement)
         reimbursement.get_receipt_url.assert_called_once_with(bulk=True)
         self.assertEqual(1, len(command.queue))
+
+    def test_update_with_error(self):
+        reimbursement = Mock()
+        reimbursement.get_receipt_url.side_effect = ConnectionError()
+        command = Command()
+        command.queue = []
+        command.update(reimbursement)
+        reimbursement.get_receipt_url.assert_called_once_with(bulk=True)
+        self.assertEqual(0, len(command.queue))
 
     @patch('jarbas.core.management.commands.receipts.bulk_update')
     @patch('jarbas.core.management.commands.receipts.Command.print_saving')

--- a/jarbas/core/tests/test_reimbursement_model.py
+++ b/jarbas/core/tests/test_reimbursement_model.py
@@ -194,11 +194,3 @@ class TestReceipt(TestCase):
         self.assertIsInstance(updated, Reimbursement)
         self.assertIsInstance(updated.receipt_url, str)
         self.assertTrue(updated.receipt_fetched)
-
-    @patch('jarbas.core.models.head')
-    def test_bulk_get_receipt_url_with_error(self, mocked_head):
-        mocked_head.side_effect = ConnectionError
-        updated = self.obj.get_receipt_url(bulk=True)
-        self.assertIsInstance(updated, Reimbursement)
-        self.assertIsNone(updated.receipt_url)
-        self.assertFalse(updated.receipt_fetched)


### PR DESCRIPTION
The `receipts` command would break if we get a HTTP error. Not anymore ; )