### PR TITLE
Refactor views moving queries logic to a QuerySet object

### DIFF
--- a/jarbas/api/views.py
+++ b/jarbas/api/views.py
@@ -13,19 +13,10 @@ from jarbas.api.serializers import (
 from jarbas.core.models import Reimbursement, Company
 
 
-def get_distinct(field, order_by, query=None):
-    qs = Reimbursement.objects.all()
-    if query:
-        filter = {order_by + '__icontains': query}
-        qs = qs.filter(**filter)
-    return qs.values(field, order_by).order_by(order_by) .distinct()
-
-
 class MultipleFieldLookupMixin(object):
 
     def get_object(self):
-        queryset = self.get_queryset()
-        queryset = self.filter_queryset(queryset)
+        queryset = self.filter_queryset(self.get_queryset())
         filter = {k: self.kwargs[k] for k in self.lookup_fields}
         return get_object_or_404(queryset, **filter)
 
@@ -105,7 +96,8 @@ class ApplicantListView(ListAPIView):
 
     def get_queryset(self):
         query = self.request.query_params.get('q')
-        return get_distinct('applicant_id', 'congressperson_name', query)
+        args = ('applicant_id', 'congressperson_name', query)
+        return Reimbursement.objects.list_distinct(*args)
 
 
 class SubquotaListView(ListAPIView):
@@ -114,7 +106,8 @@ class SubquotaListView(ListAPIView):
 
     def get_queryset(self):
         query = self.request.query_params.get('q')
-        return get_distinct('subquota_id', 'subquota_description', query)
+        args = ('subquota_id', 'subquota_description', query)
+        return Reimbursement.objects.list_distinct(*args)
 
 
 class CompanyDetailView(RetrieveAPIView):

--- a/jarbas/api/views.py
+++ b/jarbas/api/views.py
@@ -40,16 +40,12 @@ class ReimbursementListView(ListAPIView):
 
         # filter queryset
         if filters:
-            self.queryset = Reimbursement.objects.tuple_filter(**filters)
+            self.queryset = self.queryset.tuple_filter(**filters)
 
         # change ordering if needed
         order_by = self.request.query_params.get('order_by')
         if order_by == 'probability':
-            kwargs = {
-                'select': {'probability_is_null': 'probability IS NULL'},
-                'order_by': ['probability_is_null', '-probability']
-            }
-            self.queryset = self.queryset.extra(**kwargs)
+            self.queryset = self.queryset.order_by_probability()
 
         return super().get(request)
 

--- a/jarbas/api/views.py
+++ b/jarbas/api/views.py
@@ -1,15 +1,7 @@
 from django.shortcuts import get_object_or_404
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 
-from jarbas.api.serializers import (
-    ApplicantSerializer,
-    ReceiptSerializer,
-    ReimbursementSerializer,
-    SameDayReimbursementSerializer,
-    SubquotaSerializer,
-    CompanySerializer,
-    format_cnpj
-)
+from jarbas.api import serializers
 from jarbas.core.models import Reimbursement, Company
 
 
@@ -24,7 +16,7 @@ class MultipleFieldLookupMixin(object):
 class ReimbursementListView(ListAPIView):
 
     queryset = Reimbursement.objects.all()
-    serializer_class = ReimbursementSerializer
+    serializer_class = serializers.ReimbursementSerializer
 
     def get(self, request, year=None, applicant_id=None):
 
@@ -66,14 +58,14 @@ class ReimbursementDetailView(MultipleFieldLookupMixin, RetrieveAPIView):
 
     lookup_fields = ('year', 'applicant_id', 'document_id')
     queryset = Reimbursement.objects.all()
-    serializer_class = ReimbursementSerializer
+    serializer_class = serializers.ReimbursementSerializer
 
 
 class ReceiptDetailView(MultipleFieldLookupMixin, RetrieveAPIView):
 
     lookup_fields = ('year', 'applicant_id', 'document_id')
     queryset = Reimbursement.objects.all()
-    serializer_class = ReceiptSerializer
+    serializer_class = serializers.ReceiptSerializer
 
     def get_object(self):
         obj = super().get_object()
@@ -84,7 +76,7 @@ class ReceiptDetailView(MultipleFieldLookupMixin, RetrieveAPIView):
 
 class SameDayReimbursementListView(ListAPIView):
 
-    serializer_class = SameDayReimbursementSerializer
+    serializer_class = serializers.SameDayReimbursementSerializer
 
     def get_queryset(self):
         return Reimbursement.objects.same_day(**self.kwargs)
@@ -92,7 +84,7 @@ class SameDayReimbursementListView(ListAPIView):
 
 class ApplicantListView(ListAPIView):
 
-    serializer_class = ApplicantSerializer
+    serializer_class = serializers.ApplicantSerializer
 
     def get_queryset(self):
         query = self.request.query_params.get('q')
@@ -102,7 +94,7 @@ class ApplicantListView(ListAPIView):
 
 class SubquotaListView(ListAPIView):
 
-    serializer_class = SubquotaSerializer
+    serializer_class = serializers.SubquotaSerializer
 
     def get_queryset(self):
         query = self.request.query_params.get('q')
@@ -114,8 +106,8 @@ class CompanyDetailView(RetrieveAPIView):
 
     lookup_field = 'cnpj'
     queryset = Company.objects.all()
-    serializer_class = CompanySerializer
+    serializer_class = serializers.CompanySerializer
 
     def get_object(self):
         cnpj = self.kwargs.get(self.lookup_field, '00000000000000')
-        return get_object_or_404(Company, cnpj=format_cnpj(cnpj))
+        return get_object_or_404(Company, cnpj=serializers.format_cnpj(cnpj))

--- a/jarbas/core/models.py
+++ b/jarbas/core/models.py
@@ -2,7 +2,7 @@ from django.contrib.postgres.fields import JSONField
 from django.db import models
 from requests import head
 
-from jarbas.core.querysets import SameDayQuerySet
+from jarbas.core.querysets import ReimbursementQuerySet
 
 
 class Receipt:
@@ -74,7 +74,7 @@ class Reimbursement(models.Model):
     receipt_fetched = models.BooleanField('Was the receipt URL fetched?', default=False, db_index=True)
     receipt_url = models.CharField('Receipt URL', max_length=140, blank=True, null=True)
 
-    objects = models.Manager.from_queryset(SameDayQuerySet)()
+    objects = models.Manager.from_queryset(ReimbursementQuerySet)()
 
     class Meta:
         ordering = ['-issue_date']

--- a/jarbas/core/querysets.py
+++ b/jarbas/core/querysets.py
@@ -19,6 +19,14 @@ class ReimbursementQuerySet(models.QuerySet):
             applicant_id=unique_id['applicant_id']
         )
 
+    def list_distinct(self, field, order_by_field, query=None):
+        if query:
+            filter = {order_by_field + '__icontains': query}
+            self = self.filter(**filter)
+
+        self = self.values(field, order_by_field).order_by(order_by_field)
+        return self.distinct()
+
     def tuple_filter(self, **kwargs):
         filters = self._to_tuple_filter(kwargs)
         for key, values in filters.items():

--- a/jarbas/core/querysets.py
+++ b/jarbas/core/querysets.py
@@ -1,7 +1,11 @@
+import re
+from functools import reduce
+
 from django.db import models
+from django.db.models import Q
 
 
-class SameDayQuerySet(models.QuerySet):
+class ReimbursementQuerySet(models.QuerySet):
 
     def same_day(self, **kwargs):
         keys = ('year', 'applicant_id', 'document_id')
@@ -14,3 +18,15 @@ class SameDayQuerySet(models.QuerySet):
             issue_date=self.filter(**unique_id).values('issue_date'),
             applicant_id=unique_id['applicant_id']
         )
+
+    def tuple_filter(self, **kwargs):
+        filters = self._to_tuple_filter(kwargs)
+        for key, values in filters.items():
+            filter_ = reduce(lambda q, val: q | Q(**{key: val}), values, Q())
+            self = self.filter(filter_)
+        return self
+
+    @staticmethod
+    def _to_tuple_filter(filters):
+        rx = re.compile('[ ,]+')
+        return {k: tuple(rx.split(v)) for k, v in filters.items()}

--- a/jarbas/core/querysets.py
+++ b/jarbas/core/querysets.py
@@ -19,6 +19,13 @@ class ReimbursementQuerySet(models.QuerySet):
             applicant_id=unique_id['applicant_id']
         )
 
+    def order_by_probability(self):
+        kwargs = {
+            'select': {'probability_is_null': 'probability IS NULL'},
+            'order_by': ['probability_is_null', '-probability']
+        }
+        return self.extra(**kwargs)
+
     def list_distinct(self, field, order_by_field, query=None):
         if query:
             filter = {order_by_field + '__icontains': query}


### PR DESCRIPTION
This PR moves a bunch of logic that was polluting the `views.py` to a proper `QuerySet` object. It also enhance the readability of the now-called `filter_tuple` thing.