### PR TITLE
fixing text. Now the api prints the correct JSON

### DIFF
--- a/jarbas/core/management/commands/companies.py
+++ b/jarbas/core/management/commands/companies.py
@@ -28,7 +28,7 @@ class Command(LoadCommand):
         Receives path to the dataset file and create a Company object for
         each row of each file. It creates the related activity when needed.
         """
-        skip = ('main_activity', 'secondary_activty')
+        skip = ('main_activity', 'secondary_activity')
         keys = list(f.name for f in Company._meta.fields if f not in skip)
         with lzma.open(self.path, mode='rt') as file_handler:
             for row in csv.DictReader(file_handler):


### PR DESCRIPTION
This is a really simple change I've made while working on the #124 issue. On the skip list, activity was written wrong, so the API was making a not full formated JSON.