### PR TITLE
Minor enhancements in Elm & nginx for Docker 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,4 @@ COPY manage.py /code/manage.py
 COPY jarbas /code/jarbas
 WORKDIR /code
 RUN echo "America/Sao_Paulo" > /etc/timezone && dpkg-reconfigure -f noninteractive tzdata
-VOLUME /code/staticfiles
 CMD ["gunicorn", "jarbas.wsgi:application", "--reload", "--bind", "0.0.0.0:8001", "--workers", "4"]

--- a/Dockerfile-elm
+++ b/Dockerfile-elm
@@ -1,9 +1,10 @@
 FROM node:6.9.1
 RUN npm install -g yarn
 WORKDIR /code
-COPY elm-package.json elm-package.json
 COPY package.json package.json
+COPY yarn.lock yarn.lock
 COPY gulpfile.js gulpfile.js
-RUN yarn install
+COPY elm-package.json elm-package.json
+RUN yarn
 COPY jarbas jarbas
 CMD yarn assets

--- a/Dockerfile-nginx
+++ b/Dockerfile-nginx
@@ -1,3 +1,2 @@
 FROM nginx:1.11.5
 COPY contrib/nginx.docker /etc/nginx/conf.d/default.conf
-RUN mkdir -p /opt/jarbas

--- a/contrib/nginx.docker
+++ b/contrib/nginx.docker
@@ -8,7 +8,7 @@ server {
     access_log on;
 
     location /static/ {
-        alias /code/jarbas/staticfiles/;
+        alias /code/staticfiles/;
     }
 
     location / {

--- a/contrib/nginx.docker
+++ b/contrib/nginx.docker
@@ -8,7 +8,7 @@ server {
     access_log on;
 
     location /static/ {
-        alias /opt/jarbas/staticfiles/;
+        alias /code/jarbas/staticfiles/;
     }
 
     location / {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,18 +6,19 @@ services:
       context: .
       dockerfile: Dockerfile
     volumes:
-       - "staticfiles:/code/staticfiles"
-       - "./:/code"
+      - "staticfiles:/code/staticfiles"
+      - "assets:/code/jarbas/frontend/static"
+      - "./:/code"
     environment:
-       - SECRET_KEY=lets-rock
-       - DATABASE_URL=postgres://jarbas:mysecretpassword@db/jarbas
-       - CACHE_BACKEND=django.core.cache.backends.memcached.MemcachedCache
-       - CACHE_LOCATION=cache:11211
-       - DEBUG=True
+      - SECRET_KEY=lets-rock
+      - DATABASE_URL=postgres://jarbas:mysecretpassword@db/jarbas
+      - CACHE_BACKEND=django.core.cache.backends.memcached.MemcachedCache
+      - CACHE_LOCATION=cache:11211
+      - DEBUG=True
     depends_on:
-       - elm
-       - db
-       - cache
+      - elm
+      - db
+      - cache
     networks:
       backend:
       frontend:
@@ -30,7 +31,7 @@ services:
       dockerfile: Dockerfile-elm
     volumes:
       - "./:/code"
-      - "staticfiles:/code/jarbas/frontend/static"
+      - "assets:/code/jarbas/frontend/static"
       - "/code/node_modules"
     command: [yarn, watch]
 
@@ -62,6 +63,8 @@ services:
     image: memcached:1.4
 
 volumes:
+  assets:
+    external: false
   staticfiles:
     external: false
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       context: .
       dockerfile: Dockerfile-nginx
     volumes:
-      - "staticfiles:/opt/jarbas/staticfiles"
+      - "staticfiles:/code/jarbas/staticfiles"
     ports:
       - "8000:80"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       dockerfile: Dockerfile
     volumes:
       - "staticfiles:/code/staticfiles"
-      - "assets:/code/jarbas/frontend/static"
       - "./:/code"
     environment:
       - SECRET_KEY=lets-rock
@@ -31,8 +30,8 @@ services:
       dockerfile: Dockerfile-elm
     volumes:
       - "./:/code"
-      - "assets:/code/jarbas/frontend/static"
       - "/code/node_modules"
+      - "staticfiles:/code/jarbas/frontend/static"
     command: [yarn, watch]
 
   nginx:
@@ -40,7 +39,7 @@ services:
       context: .
       dockerfile: Dockerfile-nginx
     volumes:
-      - "staticfiles:/code/jarbas/staticfiles"
+      - "staticfiles:/code/staticfiles"
     ports:
       - "8000:80"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     volumes:
       - "./:/code"
       - "staticfiles:/code/jarbas/frontend/static"
-    command: [npm, run, watch]
+    command: [yarn, watch]
 
   nginx:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 version: '2'
 services:
+
   jarbas:
     build:
       context: .
@@ -29,14 +30,15 @@ services:
       dockerfile: Dockerfile-elm
     volumes:
       - "./:/code"
-      - "assets:/code/jarbas/frontend/static"
+      - "staticfiles:/code/jarbas/frontend/static"
     command: [npm, run, watch]
+
   nginx:
     build:
       context: .
       dockerfile: Dockerfile-nginx
     volumes:
-      - "assets:/opt/jarbas/staticfiles"
+      - "staticfiles:/opt/jarbas/staticfiles"
     ports:
       - "8000:80"
     depends_on:
@@ -59,8 +61,6 @@ services:
     image: memcached:1.4
 
 volumes:
-  assets:
-    external: false
   staticfiles:
     external: false
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
     volumes:
       - "./:/code"
       - "staticfiles:/code/jarbas/frontend/static"
+      - "/code/node_modules"
     command: [yarn, watch]
 
   nginx:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
       context: .
       dockerfile: Dockerfile
     volumes:
-      - "staticfiles:/code/staticfiles"
       - "./:/code"
+      - "staticfiles:/code/staticfiles"
     environment:
       - SECRET_KEY=lets-rock
       - DATABASE_URL=postgres://jarbas:mysecretpassword@db/jarbas
@@ -62,8 +62,6 @@ services:
     image: memcached:1.4
 
 volumes:
-  assets:
-    external: false
   staticfiles:
     external: false
   db:


### PR DESCRIPTION
* c819b4e : Instead of compiling `app.js` to `/code/jarbas/frontend/static` and wait for the `collectstatic` command copy it to `/code/staticfiles`, now Elm container compiles `app.js` directly into  `/code/staticfiles` for nginx to serve it.
*  9a0749c : Rename the working directory in the nginx container to match the path in other containers