### PR TITLE
Do not share node_modules folder

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       dockerfile: Dockerfile-elm
     volumes:
       - "./:/code"
+      - "/code/node_modules"
       - "assets:/code/jarbas/frontend/static"
     command: [npm, run, watch]
   nginx:


### PR DESCRIPTION
This fixies the issue @glauberramos had on #134 

The problem is when you `yarn install` dependencies on your mac, you will build an elm binary for mac, that won't work when shared with docker.

This simple line stops docker from sharing this folder and you will be able to run your own `yarn install` locally if you want. 