### PR TITLE
Install yarn the proper way in Docker

### DIFF
--- a/Dockerfile-elm
+++ b/Dockerfile-elm
@@ -1,9 +1,17 @@
 FROM node:6.9.1
-RUN npm install -g yarn
+
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+RUN sudo apt-get update
+RUN sudo apt-get install yarn
+
 WORKDIR /code
-COPY elm-package.json elm-package.json
+
+COPY yarn.lock yarn.lock
 COPY package.json package.json
+COPY elm-package.json elm-package.json
 COPY gulpfile.js gulpfile.js
-RUN yarn install
+RUN yarn install --pure-lockfile
+
 COPY jarbas jarbas
 CMD yarn assets

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ You can get the datasets running [Rosie](https://github.com/datasciencebr/rosie)
 
 #### Requirements
 
-Jarbas requires [Python 3.5](http://python.org), [Node.js 6](http://nodejs.org) with [Yarn](https://yarnpkg.com), and [PostgreSQL 9.4+](https://www.postgresql.org).
+Jarbas requires [Python 3.5](http://python.org), [Yarn](https://yarnpkg.com), and [PostgreSQL 9.4+](https://www.postgresql.org).
 
 Once you have `pip` and `yarn` available install the dependencies:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - "./:/code"
       - "/code/node_modules"
       - "assets:/code/jarbas/frontend/static"
-    command: [npm, run, watch]
+    command: [yarn, watch]
   nginx:
     build:
       context: .


### PR DESCRIPTION
Avoid using `npm install -g yarn` and follow [`yarn` docs](https://yarnpkg.com/docs/install). Maybe relevant for #137 and #129.