### PR TITLE
Add human label to new classifiers

### DIFF
--- a/jarbas/frontend/elm/Internationalization.elm
+++ b/jarbas/frontend/elm/Internationalization.elm
@@ -632,6 +632,15 @@ translate lang trans =
                             TranslationSet
                                 "Many expenses in different cities at the same day"
                                 "Muitas despesas em diferentes cidades no mesmo dia"
+                        "invalid_cnpj_cpf" ->
+                            TranslationSet
+                                "Invalid CNPJ or CPF"
+                                "CPF ou CNPJ inválidos"
+
+                        "election_expenses" ->
+                            TranslationSet
+                                "Expense in electoral campaign"
+                                "Gasto com campanha eleitoral"
 
                         _ ->
                             TranslationSet


### PR DESCRIPTION
Add human readable layers to `election_expenses` and `invalid_cnpj_cpf` (as in [1748889](https://jarbas.serenatadeamor.org/#/document/1748889)):

<img width="367" alt="screen_shot_2017-03-17_at_23_25_06" src="https://cloud.githubusercontent.com/assets/4732915/24068262/0e45c25a-0b69-11e7-9391-09301df022ee.png">

`invalid_cnpj_cpf` becomes either _Invalid CNPJ or CPF_ or _CPF ou CNPJ inválidos_. And `election_expenses` becomes either _Expense in electoral campaign_ or _Gasto com campanha eleitoral_.