### PR TITLE
Enhance user output when loading reimbursements

### DIFF
--- a/jarbas/core/management/commands/reimbursements.py
+++ b/jarbas/core/management/commands/reimbursements.py
@@ -2,6 +2,7 @@ import csv
 import lzma
 
 from django.utils.timezone import now
+from reprint import output
 
 from jarbas.core.management.commands import LoadCommand
 from jarbas.core.models import Reimbursement
@@ -13,15 +14,18 @@ class Command(LoadCommand):
     def handle(self, *args, **options):
         self.started_at = now()
         self.path = options['dataset']
-        self.count = Reimbursement.objects.count()
-        print('Starting with {:,} reimbursements'.format(self.count))
+
+        exixting = Reimbursement.objects.count()
+        print('Starting with {:,} reimbursements'.format(exixting))
+        self.count = {'updated': 0, 'created': 0, 'skip': 0}
 
         if options.get('drop', False):
             self.drop_all(Reimbursement)
-            self.count = 0
 
-        self.create_or_update(self.reimbursements)
-        self.print_count(Reimbursement, count=self.count, permanent=True)
+        with output() as status:
+            status.change(self.status)
+            self.create_or_update(self.reimbursements, status)
+
         self.mark_not_updated_reimbursements()
 
     @property
@@ -77,16 +81,36 @@ class Command(LoadCommand):
 
         return reimbursement
 
-    def create_or_update(self, reimbursements_as_dicts):
-        for count, reimbursement in enumerate(reimbursements_as_dicts):
+    def create_or_update(self, reimbursements_as_dicts, status):
+        for reimbursement in reimbursements_as_dicts:
             document_id = reimbursement.get('document_id')
-            if document_id:
-                Reimbursement.objects.update_or_create(
-                    document_id=document_id,
-                    defaults=reimbursement
-                )
-            self.print_count(Reimbursement, count=count + 1)
+
+            if not document_id:
+                self.count['skip'] += 1
+                status.change(self.status)
+                continue
+
+            _, created = Reimbursement.objects.update_or_create(
+                document_id=document_id,
+                defaults=reimbursement
+            )
+
+            key = 'created' if created else 'updated'
+            self.count[key] += 1
+            status.change(self.status)
 
     def mark_not_updated_reimbursements(self):
         qs = Reimbursement.objects.filter(last_update__lt=self.started_at)
         qs.update(available_in_latest_dataset=False)
+
+    @property
+    def status(self):
+        label = '{}s'.format(self.get_model_name(Reimbursement)).lower()
+        total = sum(map(self.count.get, self.count.keys()))
+        output = [
+            'Processed: {} lines'.format(total),
+            'Updated: {} {}'.format(self.count['updated'], label),
+            'Created: {} {}'.format(self.count['created'], label),
+            'Skip: {} {}'.format(self.count['skip'], label),
+        ]
+        return output

--- a/jarbas/core/management/commands/reimbursements.py
+++ b/jarbas/core/management/commands/reimbursements.py
@@ -15,8 +15,8 @@ class Command(LoadCommand):
         self.started_at = now()
         self.path = options['dataset']
 
-        exixting = Reimbursement.objects.count()
-        print('Starting with {:,} reimbursements'.format(exixting))
+        existing = Reimbursement.objects.count()
+        print('Starting with {:,} reimbursements'.format(existing))
         self.count = {'updated': 0, 'created': 0, 'skip': 0}
 
         if options.get('drop', False):

--- a/jarbas/core/tests/test_reimbursements_command.py
+++ b/jarbas/core/tests/test_reimbursements_command.py
@@ -1,6 +1,6 @@
 from datetime import date
 from io import StringIO
-from unittest.mock import patch
+from unittest.mock import MagicMock, call, patch
 
 from django.test import TestCase
 
@@ -92,15 +92,44 @@ class TestSerializer(TestCommand):
 class TestCreate(TestCommand):
 
     @patch.object(Reimbursement.objects, 'update_or_create')
-    @patch('jarbas.core.management.commands.reimbursements.Command.print_count')
-    def test_create_or_update(self, print_count, create):
-        reimbursements = (dict(ahoy=42, document_id=1),)
-        self.command.create_or_update(reimbursements)
-        create.assert_called_once_with(
-            document_id=1,
-            defaults=dict(document_id=1, ahoy=42)
+    @patch('jarbas.core.management.commands.reimbursements.output')
+    def test_create_or_update(self, output, create):
+        status = MagicMock()
+        reimbursements = (
+            dict(ahoy=42, document_id=1),
+            dict(ahoy=21, document_id=''),
+            dict(ahoy=84, document_id=2)
         )
-        print_count.assert_called_once_with(Reimbursement, count=1)
+        create.side_effect = ((True, True), (False, False))
+        self.command.count = dict(zip(('updated', 'created', 'skip'), [0] * 3))
+        self.command.create_or_update(reimbursements, status)
+
+        # assert update_or_create was called
+        create.assert_has_calls((
+            call(document_id=1, defaults=reimbursements[0]),
+            call(document_id=2, defaults=reimbursements[-1])
+        ))
+
+        # assert status.change was called
+        self.assertEqual(3, status.change.call_count)
+
+        # assert self.count was updated
+        expected = {
+            'updated': 1,
+            'created': 1,
+            'skip': 1
+        }
+        self.assertEqual(expected, self.command.count)
+
+    def test_status(self):
+        expected = [
+            'Processed: 42 lines',
+            'Updated: 36 reimbursements',
+            'Created: 4 reimbursements',
+            'Skip: 2 reimbursements'
+        ]
+        self.command.count = {'updated': 36, 'created': 4, 'skip': 2}
+        self.assertEqual(expected, self.command.status)
 
 
 class TestMarkNonUpdated(TestCommand):
@@ -118,13 +147,17 @@ class TestConventionMethods(TestCommand):
     @patch('jarbas.core.management.commands.reimbursements.print')
     @patch('jarbas.core.management.commands.reimbursements.Command.reimbursements')
     @patch('jarbas.core.management.commands.reimbursements.Command.create_or_update')
-    @patch('jarbas.core.management.commands.reimbursements.Command.print_count')
+    @patch('jarbas.core.management.commands.reimbursements.output')
     @patch('jarbas.core.management.commands.reimbursements.Command.mark_not_updated_reimbursements')
-    def test_handler_without_options(self, mark, print_count, create, reimbursements, print_):
+    def test_handler_without_options(self, mark, output, create, reimbursements, print_):
+        status = MagicMock()
+        output.return_value.__enter__.return_value = status
         reimbursements.return_value = (1, 2, 3)
         self.command.handle(dataset='reimbursements.xz')
         print_.assert_called_once_with('Starting with 0 reimbursements')
-        create.assert_called_once_with(reimbursements)
+        create.assert_called_once_with(reimbursements, status)
+        output.assert_called_once_with()
+        status.change.assert_called_once_with(self.command.status)
         self.assertEqual('reimbursements.xz', self.command.path)
         mark.assert_called_once_with()
 
@@ -132,13 +165,15 @@ class TestConventionMethods(TestCommand):
     @patch('jarbas.core.management.commands.reimbursements.Command.reimbursements')
     @patch('jarbas.core.management.commands.reimbursements.Command.create_or_update')
     @patch('jarbas.core.management.commands.reimbursements.Command.drop_all')
-    @patch('jarbas.core.management.commands.reimbursements.Command.print_count')
+    @patch('jarbas.core.management.commands.reimbursements.output')
     @patch('jarbas.core.management.commands.reimbursements.Command.mark_not_updated_reimbursements')
-    def test_handler_with_options(self, mark, print_count, drop_all, create, reimbursements, print_):
+    def test_handler_with_options(self, mark, output, drop_all, create, reimbursements, print_):
+        status = MagicMock()
+        output.return_value.__enter__.return_value = status
         self.command.handle(dataset='reimbursements.xz', drop=True)
         print_.assert_called_once_with('Starting with 0 reimbursements')
         drop_all.assert_called_once_with(Reimbursement)
-        create.assert_called_once_with(reimbursements)
+        create.assert_called_once_with(reimbursements, status)
         mark.assert_called_once_with()
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,5 @@ psycopg2==2.7.1
 py-gfm==0.1.3
 python-decouple==3.0
 python-memcached==1.58
+reprint==0.2.2
 requests==2.14.2


### PR DESCRIPTION
As suggested by @cacarrara in #170:

![2017-05-27 12_34_07](https://cloud.githubusercontent.com/assets/4732915/26522501/cd89c62e-42d8-11e7-94f7-d83f69abf600.gif)
