### PR TITLE
Fix django-simple-history in admin

### DIFF
--- a/jarbas/core/admin.py
+++ b/jarbas/core/admin.py
@@ -1,4 +1,6 @@
 from django.contrib import admin
+from simple_history.admin import SimpleHistoryAdmin
+
 from jarbas.core.models import Reimbursement
 
 
@@ -18,7 +20,7 @@ class SuspiciousListFilter(admin.SimpleListFilter):
         return queryset.suspicions() if self.value() == 'yes' else queryset
 
 
-class ReimbursementModelAdmin(admin.ModelAdmin):
+class ReimbursementModelAdmin(SimpleHistoryAdmin):
 
     list_display = (
         'document_id',


### PR DESCRIPTION
In Django Admin the default history was in use (which shows only changes made via the admin). This PR implements the `django-simple-history` history page showing any kind of change made in the models.