### PR TITLE
Add requeriments-dev.txt to docs & Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.5
 COPY requirements.txt /requirements.txt
+COPY requirements-dev.txt /requirements-dev.txt
 RUN python -m pip install -U pip
-RUN python -m pip install -r requirements.txt
+RUN python -m pip install -r requirements-dev.txt
 RUN apt-get update && apt-get install -y postgresql postgresql-contrib
 COPY manage.py /code/manage.py
 COPY jarbas /code/jarbas

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Jarbas requires [Python 3.5](http://python.org), [Yarn](https://yarnpkg.com), an
 
 ```console
 $ yarn install
-$ python -m pip install -r requirements.txt
+$ python -m pip install -r requirements-dev.txt
 ```
 
 ##### Python's `lzma` module


### PR DESCRIPTION
As documentation and Dockerfile target developers, this sounded reasonable. 