### PR TITLE
Add Google Analytics to dashboard

### DIFF
--- a/jarbas/core/context_processors.py
+++ b/jarbas/core/context_processors.py
@@ -1,0 +1,5 @@
+from django.conf import settings
+
+
+def google_analytics(request):
+    return {'google_analytics': settings.GOOGLE_ANALYTICS}

--- a/jarbas/dashboard/templates/admin/base.html
+++ b/jarbas/dashboard/templates/admin/base.html
@@ -1,0 +1,15 @@
+{% extends "admin/base.html" %}
+
+{% block footer %}
+  <div id="footer"></div>
+  {% if google_analytics %}
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    ga('create', '{{ google_analytics }}', 'auto');
+    ga('send', 'pageview');
+  </script>
+  {% endif %}
+{% endblock %}

--- a/jarbas/frontend/views.py
+++ b/jarbas/frontend/views.py
@@ -4,7 +4,6 @@ from django.shortcuts import render
 
 def home(request):
     context = {
-        'google_analytics': settings.GOOGLE_ANALYTICS,
         'google_street_view_api_key': settings.GOOGLE_STREET_VIEW_API_KEY
     }
     return render(request, 'frontend/home.html', context=context)

--- a/jarbas/settings.py
+++ b/jarbas/settings.py
@@ -78,6 +78,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'jarbas.core.context_processors.google_analytics',
             ],
         },
     },


### PR DESCRIPTION
Following DRY now Google Analytics is in a context processor, so both the Elm frontend and the dashboard get the value.