### PR TITLE
Enhance reimbursement detail page UI

### DIFF
--- a/jarbas/dashboard/admin.py
+++ b/jarbas/dashboard/admin.py
@@ -23,6 +23,38 @@ class ReceiptUrlWidget(Widget):
 
         url = '<div class="readonly"><a href="{}" target="_blank">{}</a></div>'
         return url.format(value, value)
+
+
+class SuspiciousWidget(Widget):
+
+    SUSPICIONS = (
+        'meal_price_outlier',
+        'over_monthly_subquota_limit',
+        'suspicious_traveled_speed_day',
+        'invalid_cnpj_cpf',
+        'election_expenses',
+        'irregular_companies_classifier'
+    )
+
+    HUMAN_NAMES = (
+        'Preço de refeição muito incomum',
+        'Extrapolou limita da (sub)quota',
+        'Muitas despesas em diferentes cidades no mesmo dia',
+        'CPF ou CNPJ inválidos',
+        'Gasto com campanha eleitoral',
+        'CNPJ irregular'
+    )
+
+    MAP = dict(zip(SUSPICIONS, HUMAN_NAMES))
+
+    def render(self, name, value, attrs=None, renderer=None):
+        value_as_dict = json.loads(value)
+        if not value_as_dict:
+            return ''
+
+        values = (self.MAP.get(k, k) for k in value_as_dict.keys())
+        suspicions = '<br>'.join(values)
+        return '<div class="readonly">{}</div>'.format(suspicions)
 class SuspiciousListFilter(SimpleListFilter):
 
     title = 'reembolso suspeito'
@@ -187,6 +219,7 @@ class ReimbursementModelAdmin(SimpleHistoryAdmin):
         if db_field.name in CUSTOM_WIDGETS:
             widgets = dict(
                 receipt_url=ReceiptUrlWidget,
+                suspicions=SuspiciousWidget
             )
             kwargs['widget'] = widgets.get(db_field.name)
         return super().formfield_for_dbfield(db_field, **kwargs)

--- a/jarbas/dashboard/admin.py
+++ b/jarbas/dashboard/admin.py
@@ -282,6 +282,12 @@ class ReimbursementModelAdmin(SimpleHistoryAdmin):
         urls = filter(dashboard.valid_url, super().get_urls())
         return list(map(self.rename_change_url, urls))
 
+    def get_object(self, request, object_id, from_field=None):
+        obj = super().get_object(request, object_id, from_field)
+        if obj and not obj.receipt_fetched:
+            obj.get_receipt_url()
+        return obj
+
     def formfield_for_dbfield(self, db_field, **kwargs):
         if db_field.name in CUSTOM_WIDGETS:
             widgets = dict(

--- a/jarbas/dashboard/static/dashboard.css
+++ b/jarbas/dashboard/static/dashboard.css
@@ -9,3 +9,9 @@
 td.field-value {
   white-space: nowrap
 }
+
+.required label,
+label.required {
+  color: #666;
+  font-weight: normal;
+}

--- a/jarbas/dashboard/tests/test_dashboard_admin.py
+++ b/jarbas/dashboard/tests/test_dashboard_admin.py
@@ -36,13 +36,17 @@ class TestDashboardSite(TestCase):
         permissions = map(self.ma.has_delete_permission, self.requests)
         self.assertNotIn(True, tuple(permissions))
 
-    def test_format_document(self):
-        obj1 = ReimbursementMock('12345678901234')
-        obj2 = ReimbursementMock('12345678901')
-        obj3 = ReimbursementMock('2345678')
-        self.assertEqual('12.345.678/9012-34', self.ma._format_document(obj1))
-        self.assertEqual('123.456.789-01', self.ma._format_document(obj2))
-        self.assertEqual('2345678', self.ma._format_document(obj3))
+    def test_format_document_with_cnpj(self):
+        obj = ReimbursementMock('12345678901234')
+        self.assertEqual('12.345.678/9012-34', self.ma._format_document(obj))
+
+    def test_format_document_with_cpf(self):
+        obj = ReimbursementMock('12345678901')
+        self.assertEqual('123.456.789-01', self.ma._format_document(obj))
+
+    def test_format_document_with_unknown(self):
+        obj = ReimbursementMock('2345678')
+        self.assertEqual('2345678', self.ma._format_document(obj))
 
 
 class TestSubuotaListfilter(TestCase):


### PR DESCRIPTION
As suggested in #186 this PR:

* Adds a HTML link to the receipt URL
* Shows subquota descriptions in pt_BR
* Shows suspicions in pt_BR

As highlighted here:

![image](https://cloud.githubusercontent.com/assets/4732915/26799631/c343148c-4a0c-11e7-9e92-973908d201fd.png)

In addition:

* Automatically tries to fetch receipt URL before loading the details page
* Normalizes suquota spelling in pt_BR as _subcota_
* Sort field names alphabetically in detail page