### PR TITLE
Subquota list filter: UI fix

### DIFF
--- a/jarbas/dashboard/admin.py
+++ b/jarbas/dashboard/admin.py
@@ -127,28 +127,28 @@ class Subquotas:
     )
 
     NUMBERS = (
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-        12,
-        13,
-        14,
-        15,
-        119,
-        120,
-        121,
-        122,
-        123,
-        137,
-        999
+        '1',
+        '2',
+        '3',
+        '4',
+        '5',
+        '6',
+        '7',
+        '8',
+        '9',
+        '10',
+        '11',
+        '12',
+        '13',
+        '14',
+        '15',
+        '119',
+        '120',
+        '121',
+        '122',
+        '123',
+        '137',
+        '999'
     )
 
     OPTIONS = sorted(zip(NUMBERS, PT_BR), key=lambda t: t[1])
@@ -179,13 +179,6 @@ class SubquotaListFilter(SimpleListFilter, Subquotas):
 
     def lookups(self, request, model_admin):
         return self.OPTIONS
-
-    def value(self):
-        value = super().value()
-        try:
-            return int(value)
-        except (TypeError, ValueError):
-            return value
 
     def queryset(self, request, queryset):
         subquota = dict(self.OPTIONS).get(self.value())

--- a/jarbas/dashboard/tests/test_dashboard_admin.py
+++ b/jarbas/dashboard/tests/test_dashboard_admin.py
@@ -64,7 +64,7 @@ class TestSubquotaListFilter(TestCase):
 
     @patch.object(SubquotaListFilter, 'value')
     def test_queryset_with_subquota(self, value):
-        value.return_value = 10
+        value.return_value = '10'
         self.list_filter.queryset(MagicMock(), self.qs)
         expected = dict(subquota_description='Telecommunication')
         self.qs.filter.assert_called_once_with(**expected)


### PR DESCRIPTION
In #201 we handled the subquotas filter using an `int` — as Django default is to [highlight filters comparing `str` (not `int`)](https://github.com/django/django/blob/master/django/contrib/admin/filters.py#L109) I changed our logic to store the lookup with `str`. This simple fix enables users to see which subquota they have selected (and we don't have to cast values from the request to `int` anymore): 

<img width="263" alt="screen shot 2017-06-21 at 17 29 32" src="https://user-images.githubusercontent.com/4732915/27405425-dbfb7ca6-56a7-11e7-8756-482d033b537d.png">
