### PR TITLE
Add link to receipt in the Jarbas Dashboard list view

### DIFF
--- a/jarbas/dashboard/admin.py
+++ b/jarbas/dashboard/admin.py
@@ -237,6 +237,7 @@ class ReimbursementModelAdmin(SimpleHistoryAdmin):
         'short_document_id',
         'jarbas',
         'rosies_tweet',
+        'receipt_link',
         'congressperson_name',
         'year',
         'subquota_translated',
@@ -304,6 +305,19 @@ class ReimbursementModelAdmin(SimpleHistoryAdmin):
 
     rosies_tweet.short_description = ''
     rosies_tweet.allow_tags = True
+
+    def receipt_link(self, obj):
+        try:
+            receipt_url = obj.get_receipt_url()
+            if receipt_url:
+                return '<a target="_blank" href="{}">📃</a>'.format(receipt_url)
+            else:
+                return ''
+        except Exception:
+            return ''
+
+    receipt_link.short_description = ''
+    receipt_link.allow_tags = True
 
     def suspicious(self, obj):
         return obj.suspicions is not None

--- a/jarbas/dashboard/admin.py
+++ b/jarbas/dashboard/admin.py
@@ -307,14 +307,9 @@ class ReimbursementModelAdmin(SimpleHistoryAdmin):
     rosies_tweet.allow_tags = True
 
     def receipt_link(self, obj):
-        try:
-            receipt_url = obj.get_receipt_url()
-            if receipt_url:
-                return '<a target="_blank" href="{}">📃</a>'.format(receipt_url)
-            else:
-                return ''
-        except Exception:
+        if not obj.receipt_url:
             return ''
+        return '<a target="_blank" href="{}">📃</a>'.format(obj.receipt_url)
 
     receipt_link.short_description = ''
     receipt_link.allow_tags = True

--- a/jarbas/frontend/elm/Reimbursement/Decoder.elm
+++ b/jarbas/frontend/elm/Reimbursement/Decoder.elm
@@ -96,6 +96,7 @@ singleDecoder lang apiKey =
             |> required "suspicions" (nullable <| keyValuePairs bool)
             |> required "rosies_tweet" (nullable string)
             |> required "receipt" (ReceiptDecoder.decoder lang)
+            |> required "receipt_link" (nullable string)
             |> hardcoded { supplier | googleStreetViewApiKey = apiKey }
             |> hardcoded RelatedTable.model
             |> hardcoded RelatedTable.model

--- a/jarbas/frontend/elm/Reimbursement/Decoder.elm
+++ b/jarbas/frontend/elm/Reimbursement/Decoder.elm
@@ -96,7 +96,6 @@ singleDecoder lang apiKey =
             |> required "suspicions" (nullable <| keyValuePairs bool)
             |> required "rosies_tweet" (nullable string)
             |> required "receipt" (ReceiptDecoder.decoder lang)
-            |> required "receipt_link" (nullable string)
             |> hardcoded { supplier | googleStreetViewApiKey = apiKey }
             |> hardcoded RelatedTable.model
             |> hardcoded RelatedTable.model


### PR DESCRIPTION
**What is the purpose of this Pull Request?**
Add link to receipt in the Jarbas Dashboard list view - close #250 

**What was done to achieve this purpose?**
Add a column in dashboard with a link (:page_with_curl:) to the receipt image

**How to test if it really works?**
Open the link at `dashboard/core/reimbursement/`, will have a :page_with_curl: in between "Reembolso" and "Nome do Parlamentar" in some lines. Filter to the reimbursements of 2012 to see the blank column when don't have a receipt image link.

**Who can help reviewing it?**
@cuducos or @jtemporal 

**TODO**

- [x] Add link
- [ ] Automated tests