### PR TITLE
Fix bug when using full text search w/ filters

### DIFF
--- a/jarbas/dashboard/admin.py
+++ b/jarbas/dashboard/admin.py
@@ -370,17 +370,17 @@ class ReimbursementModelAdmin(SimpleHistoryAdmin):
         return super().formfield_for_dbfield(db_field, **kwargs)
 
     def get_search_results(self, request, queryset, search_term):
-        if not search_term:
-            return super(ReimbursementModelAdmin, self) \
-                .get_search_results(request, queryset, search_term)
+        queryset, distinct = super(ReimbursementModelAdmin, self) \
+            .get_search_results(request, queryset, None)
 
-        query = SearchQuery(search_term, config='portuguese')
-        rank = SearchRank(F('search_vector'), query)
-        queryset = Reimbursement.objects.annotate(rank=rank) \
-            .filter(search_vector=query) \
-            .order_by('-rank')
+        if search_term:
+            query = SearchQuery(search_term, config='portuguese')
+            rank = SearchRank(F('search_vector'), query)
+            queryset = queryset.annotate(rank=rank) \
+                .filter(search_vector=query) \
+                .order_by('-rank')
 
-        return queryset, False
+        return queryset, distinct
 
 
 dashboard.register(Reimbursement, ReimbursementModelAdmin)


### PR DESCRIPTION
#252 introduced a small but nasty bug: in the dashboard if you use the search box all filters are ignored. This PR fixes this bug.

How to test it: open the dashboard, select a filter (for example, list only suspicions reimbursements) and then try a text search from the search box. If the results show the filter is combined with the text search it worked, yay!