### PR TITLE
Fix suspicions filter

### DIFF
--- a/jarbas/api/views.py
+++ b/jarbas/api/views.py
@@ -27,8 +27,9 @@ class ReimbursementListView(ListAPIView):
         filters = {k: v for k, v in zip(params, values) if v}
 
         # filter suspicions
-        if self._bool_param('suspicions'):
-            self.queryset = self.queryset.suspicions()
+        suspicions = self._bool_param('suspicions')
+        if suspicions is not None:
+            self.queryset = self.queryset.suspicions(suspicions)
 
         # filter reimbursement in latest dataset
         in_latest = self._bool_param('in_latest_dataset')

--- a/jarbas/core/querysets.py
+++ b/jarbas/core/querysets.py
@@ -29,8 +29,8 @@ class ReimbursementQuerySet(models.QuerySet):
         self = self.values(field, order_by_field).order_by(order_by_field)
         return self.distinct()
 
-    def suspicions(self):
-        return self.exclude(suspicions=None)
+    def suspicions(self, boolean):
+        return self.exclude(suspicions=None) if boolean else self.filter(suspicions=None)
 
     def in_latest_dataset(self, boolean):
         return self.filter(available_in_latest_dataset=boolean)

--- a/jarbas/core/tests/test_reimbursement_model.py
+++ b/jarbas/core/tests/test_reimbursement_model.py
@@ -85,9 +85,30 @@ class TestManager(TestReimbursement):
         data['document_id'] = 42 * 2
         del data['suspicions']
         del data['probability']
-        Reimbursement.objects.create(**data)
         Reimbursement.objects.create(**self.data)
-        self.assertEqual(1, Reimbursement.objects.suspicions().count())
+        Reimbursement.objects.create(**data)
+        self.assertEqual(1, Reimbursement.objects.suspicions(True).count())
+
+    def test_not_suspicions(self):
+        data = self.data.copy()
+        data['document_id'] = 42 * 2
+        del data['suspicions']
+        del data['probability']
+        Reimbursement.objects.create(**self.data)
+        Reimbursement.objects.create(**data)
+        self.assertEqual(1, Reimbursement.objects.suspicions(False).count())
+
+    def test_suspicions_filter(self):
+        data = self.data.copy()
+        data['document_id'] = 42 * 2
+        del data['suspicions']
+        del data['probability']
+        Reimbursement.objects.create(**self.data)
+        Reimbursement.objects.create(**data)
+        suspects = Reimbursement.objects.suspicions(True)
+        not_suspects = Reimbursement.objects.suspicions(False)
+        intersection = suspects & not_suspects
+        self.assertEqual(0, intersection.count())
 
     def test_in_latest_dataset(self):
         data = self.data.copy()

--- a/jarbas/dashboard/admin.py
+++ b/jarbas/dashboard/admin.py
@@ -85,7 +85,7 @@ class SuspiciousListFilter(JarbasListFilter):
     )
 
     def queryset(self, request, queryset):
-        return queryset.suspicions() if self.value() == 'yes' else queryset
+        return queryset.suspicions(self.value() == 'yes') if self.value() else queryset
 
 
 class MonthListFilter(JarbasListFilter):

--- a/jarbas/dashboard/admin.py
+++ b/jarbas/dashboard/admin.py
@@ -85,7 +85,11 @@ class SuspiciousListFilter(JarbasListFilter):
     )
 
     def queryset(self, request, queryset):
-        return queryset.suspicions(self.value() == 'yes') if self.value() else queryset
+        filter_option = {
+            'yes': queryset.suspicions(True),
+            'no': queryset.suspicions(False)
+        }
+        return filter_option.get(self.value(), queryset)
 
 
 class MonthListFilter(JarbasListFilter):


### PR DESCRIPTION
**What is the purpose of this Pull Request?**
Fix the 'no' option for suspicions filter - fix #256  

**What was done to achieve this purpose?**
Add a boolean as param to the suspicions queryset. The boolean is true when the value of the filter is 'yes', so it returns just the suspects and false when the value of the filter is 'no', so this method returns just the reimbursements that are not a supect.

**How to test if it really works?**
Open dashboard, click on Reimbursements, click on 'no' for the suspicions filter. if it works, the list of reimbursements shouldn't show the suspects reimbursements (Those that the last column is true) .

**Who can help reviewing it?**
@cuducos or @jtemporal 

I am not sure about the tests that I wrote, so.. special attention there.
Thank you.