### PR TITLE
Bring back Docker images from Docker Hub

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -27,9 +27,7 @@ services:
     image: memcached:1.5.1-alpine
 
   nginx:
-    build:
-      context: .
-      dockerfile: Dockerfile-nginx
+    image: datasciencebr/jarbas-server
     depends_on:
       - django
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,7 @@ version: '3'
 services:
 
   django:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: datasciencebr/jarbas-backend
     environment:
        - DATABASE_URL=postgres://jarbas:mysecretpassword@postgres/jarbas
        - ALLOWED_HOSTS=localhost,127.0.0.1
@@ -18,9 +16,7 @@ services:
       - "./contrib/data:/mnt/data"
 
   elm:
-    build:
-      context: .
-      dockerfile: Dockerfile-elm
+    image: datasciencebr/jarbas-frontend
 
   postgres:
     image: postgres:9.6.5-alpine


### PR DESCRIPTION
As suggested in #245, after that PR was merged we'll need to get back to the images from Docker Hub. This is what this PR does ; )