### PR TITLE
Keep user selected ordering in the dashboard

### DIFF
--- a/jarbas/core/querysets.py
+++ b/jarbas/core/querysets.py
@@ -49,6 +49,9 @@ class ReimbursementQuerySet(models.QuerySet):
             self = self.filter(filter_)
         return self
 
+    def was_ordered(self):
+        return bool(self.query.order_by)
+
 
 def _str_to_tuple(filters):
     """

--- a/jarbas/core/tests/test_reimbursement_model.py
+++ b/jarbas/core/tests/test_reimbursement_model.py
@@ -151,6 +151,10 @@ class TestManager(TestReimbursement):
         existing = Reimbursement.objects.in_latest_dataset(True)
         self.assertEqual(1, existing.count())
 
+    def test_was_ordered(self):
+        self.assertFalse(Reimbursement.objects.was_ordered())
+        self.assertTrue(Reimbursement.objects.order_by('pk').was_ordered())
+
 
 class TestCustomMethods(TestReimbursement):
 

--- a/jarbas/dashboard/admin.py
+++ b/jarbas/dashboard/admin.py
@@ -404,9 +404,10 @@ class ReimbursementModelAdmin(SimpleHistoryAdmin):
         if search_term:
             query = SearchQuery(search_term, config='portuguese')
             rank = SearchRank(F('search_vector'), query)
-            queryset = queryset.annotate(rank=rank) \
-                .filter(search_vector=query) \
-                .order_by('-rank')
+            queryset = queryset.annotate(rank=rank).filter(search_vector=query)
+
+            if not queryset.was_ordered():
+                queryset.order_by('-rank')
 
         return queryset, distinct
 


### PR DESCRIPTION
**What is the purpose of this Pull Request?**

In Jarbas Dashboard users could click in the table headers to *try* to sort the results by value, date, etc…

Unfortunately this user selected ordering was being overridden by the search vector rank.

Fortunately this PR fixes this bug ; )

**What was done to achieve this purpose?**

Before calling the `.order_by('-rank')` into the Django QuerySet Jarbas will check if is there any previous ordering in place.

**How to test if it really works?**

1. Run Jarbas from this branch
2. Access the dashboard (the path is `/dashboard`)
3. Search for some text using  the search bar
4. Try to filter by some clickable column headers — hopefully it'll work ; )

**Who can help reviewing it?**
@anaschwendler 