### PR TITLE
Make date import format flexible

### DIFF
--- a/jarbas/chamber_of_deputies/fields.py
+++ b/jarbas/chamber_of_deputies/fields.py
@@ -1,5 +1,3 @@
-from datetime import date
-
 from rows import fields
 
 
@@ -15,11 +13,11 @@ class IntegerField(fields.IntegerField):
 
 
 class DateAsStringField(fields.DateField):
-    INPUT_FORMAT = '%Y-%m-%dT%H:%M:%S'
+    INPUT_FORMAT = '%Y-%m-%d'  # value will be cropped to fit
     OUTPUT_FORMAT = '%Y-%m-%d'
 
     @classmethod
     def deserialize(cls, value, *args, **kwargs):
-        value = super(DateAsStringField, cls).deserialize(value)
+        value = super(DateAsStringField, cls).deserialize(value[:10])
         if value:  # useful when serializing it to Celery
             return value.strftime(cls.OUTPUT_FORMAT)

--- a/jarbas/chamber_of_deputies/tests/test_fields.py
+++ b/jarbas/chamber_of_deputies/tests/test_fields.py
@@ -1,0 +1,17 @@
+from django.test import TestCase
+
+from jarbas.chamber_of_deputies.fields import DateAsStringField
+
+
+class TestDateAsStringField(TestCase):
+
+    def test_deserialize(self):
+        dates = (
+            '2017-12-31 00:00:00',
+            '2017-12-31T00:00:00',
+            '2017-12-31'
+        )
+        expected = '2017-12-31'
+        for dt in dates:
+            with self.subTest():
+                self.assertEqual(expected, DateAsStringField.deserialize(dt))


### PR DESCRIPTION
Now it accepts `YYYY-MM-DD HH:MM:SS`, `YYYY-MM-DDTHH:MM:SS` and `YYYY-MM-DD` when reading `reimbursements.xz`.