### PR TITLE
Use SSL Offload and auto certificate renewall

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,12 @@ Copy `contrib/.env.sample` as `.env` in the project's root folder and adjust you
 To get this credentials follow [`python-twitter`
 instructions](https://python-twitter.readthedocs.io/en/latest/getting_started.html#getting-your-application-tokens).
 
+##### For the production environment
+
+* `VIRTUAL_HOST_WEB` (_str_) host used for the HTTPS certificate (for testing production settings locally you might need to add this host name to your `/etc/hosts`)
+* `LETSENCRYPT_EMAIL` (_str_) Email used to create the HTTPS certificate at Let's Encrypt
+* `HTTPS_METHOD` (_str_) if set to `noredirect` does **not** redirect from HTTP to HTTPS (default: `redirect`)
+
 ### Using Docker
 
 There are two combinations in terms of With [Docker](https://docs.docker.com/engine/installation/) and [Docker Compose](https://docs.docker.com/compose/install/)
@@ -195,6 +201,8 @@ There are two combinations in terms of With [Docker](https://docs.docker.com/eng
   * manually restarting server on change
 
 That said instructions here keep it simple and runs with the development set up. To swicth always add `-f docker-compose.yml -f docker-compose.prod.yml` after `docker-compose`.
+
+When using tghe production settings remember to double check the [appropriate environment varables](#for-the-production-environment) and to create a `.env.prod` (separate from `.env`) to hold production only values.
 
 #### Build and start services
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,7 +18,6 @@ services:
       - proxy/certs:/etc/nginx/certs
       - proxy/vhost:/etc/nginx/vhost.d
       - proxy/public:/usr/share/nginx/html
-      - ./proxy/nginx.tmpl:/app/nginx.tmpl
 
   proxy-certs:
     image: jrcs/letsencrypt-nginx-proxy-companion

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -38,7 +38,8 @@ services:
     networks:
       - backend
     environment:
-       - DEBUG=False
+      DEBUG: "False"
+      ALLOWED_HOSTS: ${VIRTUAL_HOST_WEB}
     depends_on:
       - memcached
     expose:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
-    proxy:
+  proxy:
     image: jwilder/nginx-proxy
     container_name: proxy
     ports:
@@ -15,9 +15,9 @@ services:
         condition: on-failure
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
-      - proxy/certs:/etc/nginx/certs
-      - proxy/vhost:/etc/nginx/vhost.d
-      - proxy/public:/usr/share/nginx/html
+      - proxy-certs:/etc/nginx/certs
+      - proxy-vhost:/etc/nginx/vhost.d
+      - proxy-public:/usr/share/nginx/html
 
   proxy-certs:
     image: jrcs/letsencrypt-nginx-proxy-companion
@@ -25,9 +25,9 @@ services:
       - backend
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - proxy/certs:/etc/nginx/certs:rw
-      - proxy/vhost:/etc/nginx/vhost.d
-      - proxy/public:/usr/share/nginx/html
+      - proxy-certs:/etc/nginx/certs:rw
+      - proxy-vhost:/etc/nginx/vhost.d
+      - proxy-public:/usr/share/nginx/html
     environment:
       NGINX_PROXY_CONTAINER: proxy
 
@@ -80,8 +80,9 @@ services:
 
 volumes:
   assets:
-  proxy:
+  proxy-certs:
+  proxy-vhost:
+  proxy-public:
 
 networks:
   backend:
-    driver: bridge

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,6 +18,7 @@ services:
       - proxy-certs:/etc/nginx/certs
       - proxy-vhost:/etc/nginx/vhost.d
       - proxy-public:/usr/share/nginx/html
+
   proxy-certs:
     image: jrcs/letsencrypt-nginx-proxy-companion
     networks:
@@ -29,9 +30,12 @@ services:
       - proxy-public:/usr/share/nginx/html
     environment:
       NGINX_PROXY_CONTAINER: proxy
+
   django:
     env_file:
       - .env
+    networks:
+      - backend
     environment:
        - DEBUG=False
     depends_on:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -72,10 +72,10 @@ services:
     volumes:
       - assets:/code/staticfiles
     environment:
-      VIRTUAL_HOST: jarbas.serenatadeamor.org
-      LETSENCRYPT_HOST: jarbas.serenatadeamor.org
-      LETSENCRYPT_EMAIL: jarbas@serenatadeamor.org
-      HTTPS_METHOD: redirect
+      LETSENCRYPT_HOST: ${VIRTUAL_HOST_WEB}
+      VIRTUAL_HOST: ${VIRTUAL_HOST_WEB}
+      LETSENCRYPT_EMAIL: ${LETSENCRYPT_EMAIL-op.serenatadeamor@gmail.com}
+      HTTPS_METHOD: ${HTTPS_METHOD-redirect}
       VIRTUAL_PROTO: http
 
 volumes:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,7 +18,6 @@ services:
       - proxy-certs:/etc/nginx/certs
       - proxy-vhost:/etc/nginx/vhost.d
       - proxy-public:/usr/share/nginx/html
-
   proxy-certs:
     image: jrcs/letsencrypt-nginx-proxy-companion
     networks:
@@ -30,7 +29,6 @@ services:
       - proxy-public:/usr/share/nginx/html
     environment:
       NGINX_PROXY_CONTAINER: proxy
-
   django:
     env_file:
       - .env
@@ -74,8 +72,8 @@ services:
     environment:
       LETSENCRYPT_HOST: ${VIRTUAL_HOST_WEB}
       VIRTUAL_HOST: ${VIRTUAL_HOST_WEB}
-      LETSENCRYPT_EMAIL: ${LETSENCRYPT_EMAIL-op.serenatadeamor@gmail.com}
-      HTTPS_METHOD: ${HTTPS_METHOD-redirect}
+      LETSENCRYPT_EMAIL: ${LETSENCRYPT_EMAIL:-op.serenatadeamor@gmail.com}
+      HTTPS_METHOD: ${HTTPS_METHOD:-redirect}
       VIRTUAL_PROTO: http
 
 volumes:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,5 +1,6 @@
 version: '3'
 services:
+
   proxy:
     image: jwilder/nginx-proxy
     container_name: proxy
@@ -33,13 +34,13 @@ services:
 
   django:
     env_file:
-      - .env
+      - .env.prod
     networks:
       - backend
     environment:
        - DEBUG=False
     depends_on:
-       - memcached
+      - memcached
     expose:
       - "8000"
     volumes:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,5 +1,36 @@
 version: '3'
 services:
+    proxy:
+    image: jwilder/nginx-proxy
+    container_name: proxy
+    ports:
+      - "443:443"
+      - "80:80"
+    networks:
+      - backend
+    labels:
+      - "com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy=true"
+    deploy:
+      restart_policy:
+        condition: on-failure
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - proxy/certs:/etc/nginx/certs
+      - proxy/vhost:/etc/nginx/vhost.d
+      - proxy/public:/usr/share/nginx/html
+      - ./proxy/nginx.tmpl:/app/nginx.tmpl
+
+  proxy-certs:
+    image: jrcs/letsencrypt-nginx-proxy-companion
+    networks:
+      - backend
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - proxy/certs:/etc/nginx/certs:rw
+      - proxy/vhost:/etc/nginx/vhost.d
+      - proxy/public:/usr/share/nginx/html
+    environment:
+      NGINX_PROXY_CONTAINER: proxy
 
   django:
     env_file:
@@ -35,12 +66,23 @@ services:
 
   nginx:
     image: datasciencebr/jarbas-server
+    networks:
+      - backend
     depends_on:
       - django
-    ports:
-      - "80:80"
     volumes:
       - assets:/code/staticfiles
+    environment:
+      VIRTUAL_HOST: jarbas.serenatadeamor.org
+      LETSENCRYPT_HOST: jarbas.serenatadeamor.org
+      LETSENCRYPT_EMAIL: jarbas@serenatadeamor.org
+      HTTPS_METHOD: redirect
+      VIRTUAL_PROTO: http
 
 volumes:
   assets:
+  proxy:
+
+networks:
+  backend:
+    driver: bridge


### PR DESCRIPTION
Change prod docker-compose file to use proxy to handle SSL Offload and auto SSL certificate renewal.

**What is the purpose of this Pull Request?**
Easy the certificate renewall and related operations

**What was done to achieve this purpose?**
Used jwilder/nginx-proxy and jrcs/letsencrypt-nginx-proxy-companion container images.

**How to test if it really works?**
```
docker-compose up -d && docker-compose logs -f --tail=10
``` 
Certificate shall be generated on start.

**Who can help reviewing it?**
cuducos

**TODO**
- [x] Should we support Swarm Mode? Bridge networks may not work as expected. Use overlay instead.
- [ ] Should we avoid bind-mounting docker socket on the edge proxy? Use a separate container to generate nginx configuration instead.
