### PR TITLE
Use parallel argument in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_script:
   - python manage.py collectstatic --no-input
 
 script:
-  - coverage run manage.py test -v 3
+  - coverage run manage.py test --parallel
 
 after_success:
   - coveralls

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Not sure? Test it!
 
 ```console
 $ docker-compose run --rm django python manage.py check
-$ docker-compose run --rm django python manage.py test
+$ docker-compose run --rm django python manage.py test --parallel
 ```
 
 If you use Windows do not use the `--parallel` argument ([it is not compatible](https://docs.djangoproject.com/en/1.11/ref/django-admin/#cmdoption-test-parallel)).

--- a/README.md
+++ b/README.md
@@ -255,8 +255,10 @@ Not sure? Test it!
 
 ```console
 $ docker-compose run --rm django check
-$ docker-compose run --rm django test
+$ docker-compose run --rm django test --parallel
 ```
+
+If you use Windows do not use the `--parallel` argument ([it is not compatible](https://docs.djangoproject.com/en/1.11/ref/django-admin/#cmdoption-test-parallel)).
 
 ### Local install
 
@@ -332,6 +334,8 @@ Not sure? Test it!
 $ python manage.py check
 $ python manage.py test
 ```
+
+If you use Windows do not use the `--parallel` argument ([it is not compatible](https://docs.djangoproject.com/en/1.11/ref/django-admin/#cmdoption-test-parallel)).
 
 #### Ready!
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ python-twitter==3.3
 reprint==0.3.0 # pyup: ignore
 requests==2.18.4
 rows==0.3.1
+tblib # pyup: ignore


### PR DESCRIPTION
**What is the purpose of this Pull Request?**
Make tests run quicker.

**What was done to achieve this purpose?**
Added `--parallel` argument to docs and `.travis.yml` as well as a lib to fix traceback when using this option.

**How to test if it really works?**
Only only in UNIX based systems (sorry, according to Django `--parallel` argument is [not compatible with Windows](https://docs.djangoproject.com/en/1.11/ref/django-admin/#cmdoption-test-parallel)): Copy and paste the test command from the `README.md` and compare to the time taken without the added argument.

For example:

```console
$ docker-compose run --rm django test && docker-compose run --rm django test  --parallel
```
The first result is what we have today, the second is with multiple tests running in parallel.

**Who can help reviewing it?**
@anaschwendler 