### PR TITLE
Remove entrypoint from production compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,5 +32,4 @@ RUN set -ex && \
 
 HEALTHCHECK --interval=1m --timeout=2m CMD goss -g /goss/goss.yaml validate
 EXPOSE 8000
-ENTRYPOINT ["python", "manage.py"]
-CMD ["runserver", "0.0.0.0:8000"]
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/README.md
+++ b/README.md
@@ -215,16 +215,16 @@ $ docker-compose up -d
 Creating the database and applying migrations:
 
 ```
-$ docker-compose run --rm django migrate
+$ docker-compose run --rm django python manage.py migrate
 ```
 
 Seeding it with sample data:
 
 ```console
-$ docker-compose run --rm django reimbursements /mnt/data/reimbursements_sample.xz
-$ docker-compose run --rm django companies /mnt/data/companies_sample.xz
-$ docker-compose run --rm django suspicions /mnt/data/suspicions_sample.xz
-$ docker-compose run --rm django tweets
+$ docker-compose run --rm django python manage.py reimbursements /mnt/data/reimbursements_sample.xz
+$ docker-compose run --rm django python manage.py companies /mnt/data/companies_sample.xz
+$ docker-compose run --rm django python manage.py suspicions /mnt/data/suspicions_sample.xz
+$ docker-compose run --rm django python manage.py tweets
 ```
 
 If you're interesting in having a database full of data you can get the datasets running [Rosie](https://github.com/datasciencebr/rosie).
@@ -235,7 +235,7 @@ To add a fresh new `reimbursements.xz` or `suspicions.xz` brewed by [Rosie](http
 For text search in the dashboard:
 
 ```console
-$ docker-compose run --rm django searchvector
+$ docker-compose run --rm django python manage.py searchvector
 ```
 
 #### Acessing Jabas
@@ -244,7 +244,7 @@ You can access it at [`localhost:8000`](http://localhost:8000/) in development m
 
 
 ```console
-$ docker-compose run --rm django reimbursements path/to/my/fresh_new_reimbursements.xz
+$ docker-compose run --rm django python manage.py reimbursements path/to/my/fresh_new_reimbursements.xz
 ```
 
 To change any of the default environment variables defined in the `docker-compose.yml` just export it in a local environment variable, so when you run Jarbas it will get them.
@@ -254,8 +254,8 @@ To change any of the default environment variables defined in the `docker-compos
 Not sure? Test it!
 
 ```console
-$ docker-compose run --rm django check
-$ docker-compose run --rm django test
+$ docker-compose run --rm django python manage.py check
+$ docker-compose run --rm django python manage.py test
 ```
 
 ### Local install

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -46,8 +46,7 @@ services:
       - "8000"
     volumes:
       - assets:/code/staticfiles
-    entrypoint: ["gunicorn", "jarbas.wsgi:application", "--reload", "--bind", "0.0.0.0:8000", "--workers", "4"]
-    command: []
+    command: ["gunicorn", "jarbas.wsgi:application", "--reload", "--bind", "0.0.0.0:8000", "--workers", "4"]
 
   tasks:
     env_file:


### PR DESCRIPTION
This is needed since on production we still need some Django commands such as collectstatic and migrate

**What is the purpose of this Pull Request?**
Having `gunicorn` as an `entrypoint` for the Django production container makes it difficult to run Django commands such as `python manage.py collectstatic` or `python manage.py migrate`.

**What was done to achieve this purpose?**
Set `gunicorn` as a `command` not as `entrypoint`.

**How to test if it really works?**

Comment out the `image: …` and add to `docker-compose.yml` on the `django` container:

```yaml
  build:
    context: .
```

Then `docker-compose -f docker-compose.yml -f docker-compose.prod.yml run django collectstatic --noinput`