### PR TITLE
Backward compatibility for URLs aiming at the Elm interface for a rec…

### DIFF
--- a/jarbas/dashboard/static/dashboard.js
+++ b/jarbas/dashboard/static/dashboard.js
@@ -1,0 +1,30 @@
+/*
+ *
+ * This JS assures backward compatibility for URLs aiming at the Layers app
+ * version os a receipt, i.e. the Elm interface.
+ *
+ * Old URLs such as:
+ * https://domain.tld/#/documentId/42
+ *
+ * will be redirected by the backend to:
+ * https://domain.tld//dashboard/chamber_of_deputies/reimbursement/#/documentId/42
+ *
+ * and then this JS will correct it to:
+ * https://domain.tld/layers/#/documentId/42
+ *
+ * */
+
+var redirectedPath = '/dashboard/chamber_of_deputies/reimbursement/';
+var layersPath = '/layers/';
+var hash = 'documentId'; // we look only for fragments containing this word
+
+var isLayersUrl = function () {
+  if (redirectedPath !== window.location.pathname) return false;
+  return window.location.hash.split('/').indexOf(hash) >= 0;
+};
+
+var redirectToLayers = function () {
+  if (isLayersUrl()) window.location.pathname =layersPath;
+};
+
+redirectToLayers();

--- a/jarbas/dashboard/templates/admin/base_site.html
+++ b/jarbas/dashboard/templates/admin/base_site.html
@@ -4,7 +4,10 @@
 
 {% block title %}{{ title|rename_title }} | {{ site_title|default:_('Jarbas Dashboard') }}{% endblock %}
 
-{% block extrahead %}<link rel="stylesheet" type="text/css" href="{% static "dashboard.css" %}" />{% endblock %}
+{% block extrahead %}
+<script src="{% static 'dashboard.js' %}"> async></script>
+<link rel="stylesheet" type="text/css" href="{% static 'dashboard.css' %}" />
+{% endblock %}
 
 {% block blockbots %}<meta name="robots" content="INDEX, FOLLOW" />{% endblock %}
 


### PR DESCRIPTION
**What is the purpose of this Pull Request?**

When we directed the homepage to the Dashboard we broke [@RosieDaSerenata](https://twitter.com/RosieDaSerenata) links. This PR fixes that making Jarbas backward compatible with these links.

**What was done to achieve this purpose?**

A JS was added to the Dashboard to check if the URL matches one of those tweeted by Rosie, if so it redirects to the proper URL.

A JS was needed because URL fragment identifiers (string after the `#` in the URL) are not passed to the server (even if some agents pass it, it's mostly considered a bug not a feature) and the Elm interface links are based on URL fragment identifiers.

**How to test if it really works?**

Access any URL such as [`http://localhost:8000/#/documentId/5627913`](http://localhost:8000/#/documentId/5627913) and check if it redirects to [`http://localhost:8000/layers/#/documentId/5627913`](http://localhost:8000/layers/#/documentId/5627913) (there is an extra `layers/` in the redirection URL path).

**Who can help reviewing it?**

@anaschwendler 

**TODO**

Once this is merged @Irio can finally (re)point the DNS to the new servers.