### PR TITLE
Use slim to reduce Elm container

### DIFF
--- a/Dockerfile-elm
+++ b/Dockerfile-elm
@@ -1,4 +1,4 @@
-FROM node:8.4.0
+FROM node:8.4.0-slim
 
 # npm5 issue with updating itself: https://github.com/npm/npm/issues/18278
 # RUN npm install -g npm@latest


### PR DESCRIPTION
**What is the purpose of this Pull Request?**

The Docker image to render Elm was too big (723MB):

```
$ docker images | grep jarbas
datasciencebr/jarbas-frontend   latest              26f5ad1240ee        12 days ago         723MB
datasciencebr/jarbas-backend    latest              dde71b4b84b6        12 days ago         181MB
```

**What was done to achieve this purpose?**

I suggest we use the `slim` version of the `node` Docker image instead (I tried `alpine` but ended up with some `npm` errors). This reduced the image size in 61%:

```
jarbas_elm_alpine               latest              06f7c4734ab6        2 minutes ago       279MB
```

**How to test if it really works?**

Edit `docker-compose.yml` to use `Dockerfile-elm` file instead of pulling `datasciencebr/jarbas-frontend`. Build containers, run Jarbas and check if [Layers (`localhost:8000/layers/`)](http://localhost:8000/layers/) doesn't crash.

**Who can help reviewing it?**

@anaschwendler 