### PR TITLE
Change domain: serenatadeamor.org -> serenata.ai

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -81,7 +81,7 @@ services:
     environment:
       LETSENCRYPT_HOST: ${VIRTUAL_HOST_WEB}
       VIRTUAL_HOST: ${VIRTUAL_HOST_WEB}
-      LETSENCRYPT_EMAIL: ${LETSENCRYPT_EMAIL:-op.serenatadeamor@gmail.com}
+      LETSENCRYPT_EMAIL: ${LETSENCRYPT_EMAIL:-contato@serenata.ai}
       HTTPS_METHOD: ${HTTPS_METHOD:-redirect}
       VIRTUAL_PROTO: http
 

--- a/jarbas/chamber_of_deputies/tests/test_reimbursement_model.py
+++ b/jarbas/chamber_of_deputies/tests/test_reimbursement_model.py
@@ -110,7 +110,7 @@ class TestManager(TestReimbursement):
         # let's create a reimbursement with some receipt_url (self.data has none)
         data = self.data.copy()
         data['document_id'] = 42 * 2
-        data['receipt_url'] = 'http://serenatadeamor.org/'
+        data['receipt_url'] = 'http://serenata.ai/'
 
         # now let's save two reimbursements: one with and another one without receipt_url
         Reimbursement.objects.create(**data)

--- a/jarbas/layers/elm/Layout.elm
+++ b/jarbas/layers/elm/Layout.elm
@@ -76,6 +76,6 @@ drawer model =
             drawerLinks
             [ ( "/static/ceap-datasets.html", translate model.lang AboutDatasets )
             , ( "http://github.com/okfn-brasil/jarbas", translate model.lang AboutJarbas )
-            , ( "https://serenatadeamor.org", translate model.lang AboutSerenata )
+            , ( "https://serenata.ai", translate model.lang AboutSerenata )
             ]
     ]


### PR DESCRIPTION
**What is the purpose of this Pull Request?**

Jarbas has some references to the _old_ domain `serenatadeamor.org`.

**What was done to achieve this purpose?**

This PR updates them to use `serenata.ai` (and the email, from the Gmail account to the new domain account).