### PR TITLE
Remove parallel options from CI test command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ python:
   - 3.5
 
 addons:
-    postgresql: "9.6"
+  postgresql: "9.6"
 
 services:
-    - postgresql
+  - postgresql
 
 env:
   - DATABASE_URL="postgres://postgres@localhost/jarbas"
@@ -26,7 +26,7 @@ before_script:
   - python manage.py collectstatic --no-input
 
 script:
-  - coverage run manage.py test --parallel
+  - coverage run manage.py test
 
 after_success:
   - coveralls


### PR DESCRIPTION
Commit a86f4b9f8797aa1de9b1e8734d3084aa63832ba0 removed parallel tests, but `.travis.yml` was forgotten. This PR/commit fixes that (and apply some linter to the YAML).